### PR TITLE
Host for free

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -45,7 +45,8 @@ export default function LoginPage() {
         username: formData.email, // Utilise l'email comme username
         password: formData.password,
       }
-      const res = await axios.post("http://localhost:8000/api/login/", payload)
+      const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"
+      const res = await axios.post(`${API}/login/`, payload)
       localStorage.setItem("isAuthenticated", "true")
       localStorage.setItem("userType", res.data.userType)
       router.push(res.data.userType === "client" ? "/client-dashboard" : "/freelancer-dashboard")

--- a/app/auth/register/page.tsx
+++ b/app/auth/register/page.tsx
@@ -66,7 +66,8 @@ export default function RegisterPage() {
         location: formData.location,
         acceptTerms: formData.acceptTerms,
       }
-      const res = await axios.post("http://localhost:8000/api/register/", payload)
+      const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"
+      const res = await axios.post(`${API}/register/`, payload)
       setSuccessMsg("Utilisateur ajouté avec succès !")
       setTimeout(() => {
         localStorage.setItem("isAuthenticated", "true")

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -31,8 +31,10 @@ export default function HomePage() {
   const [selectedCategory, setSelectedCategory] = useState("all")
   const [testResult, setTestResult] = useState<string>("")
 
+  const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"
+
   useEffect(() => {
-    axios.get("http://localhost:8000/api/projects/")
+    axios.get(`${API_BASE}/projects/`)
       .then(res => setTestResult("Connexion OK, projets reçus : " + res.data.length))
       .catch(err => setTestResult("Erreur de connexion au backend"))
   }, [])

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -7,7 +7,8 @@ export default function ProjectsPage() {
   const [projects, setProjects] = useState([])
 
   useEffect(() => {
-    axios.get("http://localhost:8000/api/projects/")
+    const API = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000/api"
+    axios.get(`${API}/projects/`)
       .then(res => setProjects(res.data))
       .catch(err => console.error(err))
   }, [])

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "next.config.mjs", "use": "@vercel/next" }
+  ],
+  "ignoreCommand": "echo Skipping backend build",
+  "env": {
+    "NEXT_PUBLIC_API_URL": "${NEXT_PUBLIC_API_URL}"
+  }
+}


### PR DESCRIPTION
Update frontend API calls to use an environment variable and add Vercel config.

This change allows the Next.js frontend to be deployed on Vercel by making the backend API URL configurable via `NEXT_PUBLIC_API_URL`, falling back to `localhost` for local development.

---
<a href="https://cursor.com/background-agent?bcId=bc-a42bc010-537f-4cd5-b886-1ad203d5c437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a42bc010-537f-4cd5-b886-1ad203d5c437"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

